### PR TITLE
fix: [LSPD-6299] bump logback from 1.2.11 to 1.4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <java.version>17</java.version>
         <junitparams.version>1.1.1</junitparams.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.11</logback.version>
+        <logback.version>1.4.11</logback.version>
         <guava.version>31.0.1-jre</guava.version>
         <jsr305.version>3.0.2</jsr305.version>
         <logstash-logback-encoder.version>8.0</logstash-logback-encoder.version>


### PR DESCRIPTION
The LSPD-5749 backend upgrade dependencies for 25.1 issue somehow downgraded logback from 1.4.11 to 1.2.11

That caused (for an unknown reason) logs to flood