### PR TITLE
[LSPD-7327] Add prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>com.livingobjects.neo4j</groupId>
     <artifactId>neo4j-lo-extensions</artifactId>
-    <version>1.28.2</version>
+    <version>1.28.3</version>
 
     <packaging>bundle</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <guava.version>31.0.1-jre</guava.version>
         <jsr305.version>3.0.2</jsr305.version>
         <opencsv.version>5.10</opencsv.version>
+        <prometheus.version>1.8.0</prometheus.version>
         <junit.version>4.13.2</junit.version>
         <assertj-core.version>3.27.7</assertj-core.version>
     </properties>
@@ -85,6 +86,23 @@
             <artifactId>neo4j-harness</artifactId>
             <version>${neo4j.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Metrics -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-core</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
+            <version>${prometheus.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/livingobjects/neo4j/ExportExtension.java
+++ b/src/main/java/com/livingobjects/neo4j/ExportExtension.java
@@ -110,17 +110,12 @@ public final class ExportExtension {
     private final MetaSchema metaSchema;
     private final Log log;
 
-    // Don't clean up this "unused" variable:
-    // No startup entry point is available in the Neo4j extension,
-    // so we need to reference the metrics somewhere for them to start the server anb be exposed
-    private final PmtMetrics metrics;
-
     public ExportExtension(@Context DatabaseManagementService dbms, @Context Log log) {
         this.graphDb = dbms.database(dbms.listDatabases().get(0));
         this.templatedPlanetFactory = new TemplatedPlanetFactory(graphDb);
         this.planetFactory = new PlanetFactory(graphDb);
         this.log = log;
-        this.metrics = PmtMetrics.get(log);
+        PmtMetrics.get(log);
         try (Transaction tx = graphDb.beginTx()) {
             this.metaSchema = new MetaSchema(tx);
         }

--- a/src/main/java/com/livingobjects/neo4j/ExportExtension.java
+++ b/src/main/java/com/livingobjects/neo4j/ExportExtension.java
@@ -17,6 +17,7 @@ import com.livingobjects.neo4j.helper.PlanetFactory;
 import com.livingobjects.neo4j.helper.PropertyConverter;
 import com.livingobjects.neo4j.helper.TemplatedPlanetFactory;
 import com.livingobjects.neo4j.loader.MetaSchema;
+import com.livingobjects.neo4j.metrics.PmtMetrics;
 import com.livingobjects.neo4j.model.export.CrossRelationship;
 import com.livingobjects.neo4j.model.export.Lineage;
 import com.livingobjects.neo4j.model.export.LineageListNaturalComparator;
@@ -109,11 +110,17 @@ public final class ExportExtension {
     private final MetaSchema metaSchema;
     private final Log log;
 
+    // Don't clean up this "unused" variable:
+    // No startup entry point is available in the Neo4j extension,
+    // so we need to reference the metrics somewhere for them to start the server anb be exposed
+    private final PmtMetrics metrics;
+
     public ExportExtension(@Context DatabaseManagementService dbms, @Context Log log) {
         this.graphDb = dbms.database(dbms.listDatabases().get(0));
         this.templatedPlanetFactory = new TemplatedPlanetFactory(graphDb);
         this.planetFactory = new PlanetFactory(graphDb);
         this.log = log;
+        this.metrics = PmtMetrics.get(log);
         try (Transaction tx = graphDb.beginTx()) {
             this.metaSchema = new MetaSchema(tx);
         }

--- a/src/main/java/com/livingobjects/neo4j/SchemaTemplateExtension.java
+++ b/src/main/java/com/livingobjects/neo4j/SchemaTemplateExtension.java
@@ -45,6 +45,7 @@ import static com.livingobjects.neo4j.model.iwan.GraphModelConstants.VERSION;
 
 @Path("/schema")
 public class SchemaTemplateExtension {
+
     private final GraphDatabaseService graphDb;
     private final ObjectMapper json = new ObjectMapper();
     private final Log log;

--- a/src/main/java/com/livingobjects/neo4j/metrics/PmtMetrics.java
+++ b/src/main/java/com/livingobjects/neo4j/metrics/PmtMetrics.java
@@ -42,15 +42,15 @@ public class PmtMetrics {
 
     private PmtMetrics(Log log) {
         try {
-            log.info("Will start Prometheus HTTP server on port {}", PORT);
+            log.debug("Will start Prometheus HTTP server on port %s".formatted(PORT));
             HTTPServer.builder()
                     .port(PORT)
                     .buildAndStart();
-            log.info("Prometheus HTTP server started on port {}", PORT);
+            log.debug("Prometheus HTTP server started on port %s".formatted(PORT));
 
             JvmMetrics.builder().register();
         } catch (IOException e) {
-            log.error("Could not start Prometheus HTTP server on port {}", PORT, e);
+            log.error("Could not start Prometheus HTTP server on port %s".formatted(PORT), e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/livingobjects/neo4j/metrics/PmtMetrics.java
+++ b/src/main/java/com/livingobjects/neo4j/metrics/PmtMetrics.java
@@ -1,0 +1,57 @@
+/*
+ * PmtMetrics.java
+ * Created on Jul 15, 2026, 3:47 PM
+ *
+ * Copyright 2026 BlueCat Networks (USA) Inc. and its affiliates and licensors. All Rights Reserved.
+ *
+ * BlueCat Networks and its licensors hereby assert and retain all rights, title, and interest in and to the code,
+ * including any and all modifications, enhancements, or derivative works thereof (collectively, the "Code"). This
+ * includes, but is not limited to, all intellectual property rights, whether registered or unregistered, associated
+ * with the Code. The Code contains trade secrets and proprietary and confidential information of BlueCat Networks
+ * and its licensors. It is protected under applicable worldwide copyright and trade secret laws. No rights, title,
+ * or interest in the Code are transferred to any third party without the explicit written consent of BlueCat
+ * Networks. Any unauthorized use, reproduction, or distribution of the Code is strictly prohibited and may result in
+ * legal action.
+ */
+package com.livingobjects.neo4j.metrics;
+
+import io.prometheus.metrics.exporter.httpserver.HTTPServer;
+import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
+import org.neo4j.logging.Log;
+
+import java.io.IOException;
+
+/**
+ *
+ *
+ * @author Baptiste Le Bail
+ */
+public class PmtMetrics {
+
+    private static final int PORT = 9435;
+
+    private static PmtMetrics INSTANCE;
+
+    public static PmtMetrics get(Log log) {
+        if (INSTANCE == null) {
+            INSTANCE = new PmtMetrics(log);
+        }
+
+        return INSTANCE;
+    }
+
+    private PmtMetrics(Log log) {
+        try {
+            log.info("Will start Prometheus HTTP server on port {}", PORT);
+            HTTPServer.builder()
+                    .port(PORT)
+                    .buildAndStart();
+            log.info("Prometheus HTTP server started on port {}", PORT);
+
+            JvmMetrics.builder().register();
+        } catch (IOException e) {
+            log.error("Could not start Prometheus HTTP server on port {}", PORT, e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/livingobjects/neo4j/metrics/PmtMetrics.java
+++ b/src/main/java/com/livingobjects/neo4j/metrics/PmtMetrics.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  */
 public class PmtMetrics {
 
-    private static final int PORT = 9435;
+    private static final int PORT = 9440;
 
     private static PmtMetrics INSTANCE;
 


### PR DESCRIPTION
Prometheus metrics were added to the `ExportExtension` because there is no startup entry point in the neo4j extension model.