### PR TITLE
Hotfix/1.28.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>com.livingobjects.neo4j</groupId>
     <artifactId>neo4j-lo-extensions</artifactId>
-    <version>1.28.3</version>
+    <version>1.28.4</version>
 
     <packaging>bundle</packaging>
 

--- a/src/main/java/com/livingobjects/neo4j/ExportExtension.java
+++ b/src/main/java/com/livingobjects/neo4j/ExportExtension.java
@@ -2,6 +2,7 @@ package com.livingobjects.neo4j;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -12,6 +13,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.MoreCollectors;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
+import com.livingobjects.neo4j.export.LineageChain;
+import com.livingobjects.neo4j.export.NodePath;
 import com.livingobjects.neo4j.helper.PlanetByContext;
 import com.livingobjects.neo4j.helper.PlanetFactory;
 import com.livingobjects.neo4j.helper.PropertyConverter;
@@ -73,7 +76,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -253,16 +255,29 @@ public final class ExportExtension {
         if (pagination.isPresent() && pagination.get().offset > sortedLines.size()) {
             return EMPTY_PAGINATED_LINEAGE;
         }
+        int start = pagination
+                .map(p -> p.offset)
+                .orElse(0);
         int end = pagination
                 .map(p -> Math.min(p.offset + p.limit, sortedLines.size()))
                 .orElse(sortedLines.size());
-        return new PaginatedLineages() {
+        int total = sortedLines.size();
+        List<Pair<List<Lineage>, List<Map<String, Object>>>> window = pagination.isPresent() ?
+                sortedLines.subList(start, end) :
+                sortedLines;
 
-            private List<Pair<List<Lineage>, List<Map<String, Object>>>> lineages() {
-                return pagination
-                        .map(p -> sortedLines.subList(p.offset, end))
-                        .orElse(sortedLines);
+        // only initialize properties for requested window
+        for (Pair<List<Lineage>, List<Map<String, Object>>> line : window) {
+            List<Lineage> lineageAtIndex = line.first;
+            for (int i = 0; i < lineageAtIndex.size(); i++) {
+                Lineage l = lineageAtIndex.get(i);
+                if (l != null) {
+                    initializePropertiesToExport(lineages.get(i), l);
+                }
             }
+        }
+
+        return new PaginatedLineages() {
 
             @Override
             public ImmutableSet<String> attributesToExport() {
@@ -282,7 +297,7 @@ public final class ExportExtension {
 
             @Override
             public List<Pair<List<ExportQueryResult>, List<RelationshipQueryResult>>> results() {
-                return lineages()
+                return window
                         .stream()
                         .map(lineagesAndRelProps ->
                                 new Pair<>(
@@ -298,9 +313,7 @@ public final class ExportExtension {
 
             @Override
             public int start() {
-                return pagination
-                        .map(p -> p.offset)
-                        .orElse(0);
+                return start;
             }
 
             @Override
@@ -310,7 +323,7 @@ public final class ExportExtension {
 
             @Override
             public int total() {
-                return sortedLines.size();
+                return total;
             }
         };
     }
@@ -345,7 +358,8 @@ public final class ExportExtension {
         }
     }
 
-    private PaginatedLineages extract(FullQuery initQuery) {
+    @VisibleForTesting
+    PaginatedLineages extract(FullQuery initQuery) {
         try (Transaction tx = graphDb.beginTx()) {
             MetaSchema metaSchema = new MetaSchema(tx);
 
@@ -391,9 +405,6 @@ public final class ExportExtension {
                     initializePropertiesList(lineages.get(i), l);
                 }
                 lineages.get(i).consolidatePropertiesTypeByType();
-                for (Lineage l : filter) {
-                    initializePropertiesToExport(lineages.get(i), l);
-                }
             }
             List<Pair<List<Lineage>, List<Map<String, Object>>>> filteredLines = constructLines(
                     lineages,
@@ -450,14 +461,18 @@ public final class ExportExtension {
                 return Lists.newArrayList();
             }
         }
-        List<Pair<List<Lineage>, List<Relationship>>> lines = Lists.newArrayList();
-        constructLinesR(lines,
+        List<LineageChain> chains = Lists.newArrayList();
+        constructLinesR(chains,
                 ImmutableList.copyOf(lineages.stream()
                         .map(ImmutableList::copyOf)
                         .collect(toImmutableList())
                 ),
                 relationQueries,
                 metaRelations);
+
+        List<Pair<List<Lineage>, List<Relationship>>> lines = chains.stream()
+                .map(chain -> new Pair<List<Lineage>, List<Relationship>>(chain.toLineageList(), chain.toRelationshipList()))
+                .collect(Collectors.toCollection(Lists::newArrayList));
 
         // replace useless lineages with empty lineage
         for (int i = 0; i < exportQueries.size(); i++) {
@@ -535,65 +550,57 @@ public final class ExportExtension {
      * lines[i] and lines[i+1] are linked by the relationship described by relationQueries[i] and metaRelations[i]
      */
     private void constructLinesR(
-            List<Pair<List<Lineage>, List<Relationship>>> lines,
+            List<LineageChain> lines,
             ImmutableList<ImmutableList<Lineage>> allLineages,
             ImmutableList<RelationshipQuery> relationQueries,
             ImmutableList<CrossRelationship> metaRelations
     ) {
         if (lines.isEmpty()) {
-            allLineages.get(0).forEach(l -> lines.add(new Pair<>(Lists.newArrayList(l), Lists.newArrayList())));
+            allLineages.get(0).forEach(l -> lines.add(LineageChain.first(l)));
             constructLinesR(lines, allLineages, relationQueries, metaRelations);
             return;
         }
-        int i = lines.get(0).first.size() - 1;
+        int i = lines.get(0).size - 1;
         if (allLineages.size() == i + 1) {
             return;
         }
         List<Lineage> nextLineages = allLineages.get(i + 1);
+        RelationshipQuery relationQuery = relationQueries.get(i);
+        CrossRelationship metaRelation = metaRelations.get(i);
+        Direction direction = relationQuery.direction;
+        String destType = direction == INCOMING ? metaRelation.originType : metaRelation.destinationType;
+        // Index nextLineages by their destType node once, instead of linearly scanning it for every candidate
+        // relationship of every line (this loop is otherwise an O(lines x nextLineages) nested-loop join).
+        Map<Node, List<Lineage>> nextLineagesByDestNode = nextLineages.stream()
+                .collect(Collectors.groupingBy(l -> l.nodesByType.get(destType)));
+
         ImmutableList.copyOf(lines)
-                .forEach(pair -> {
-                    Lineage l = pair.first.get(i);
-                    List<Pair<Lineage, Relationship>> toAdd = getMatchingLineageAndRelationProperties(l,
-                            nextLineages,
-                            metaRelations.get(i),
-                            relationQueries.get(i)
+                .forEach(chain -> {
+                    List<Pair<Lineage, Relationship>> toAdd = getMatchingLineageAndRelationProperties(chain.lineage,
+                            nextLineagesByDestNode,
+                            metaRelation,
+                            relationQuery
                     );
-                    lines.remove(pair);
-                    lines.addAll(addNext(pair, toAdd));
+                    lines.remove(chain);
+                    toAdd.forEach(match -> lines.add(chain.append(match.first, match.second)));
                 });
         if (!lines.isEmpty()) {
             constructLinesR(lines, allLineages, relationQueries, metaRelations);
         }
     }
 
-    private List<Pair<List<Lineage>, List<Relationship>>> addNext(
-            Pair<List<Lineage>, List<Relationship>> initial,
-            List<Pair<Lineage, Relationship>> next) {
-        return next.stream()
-                .map(lineageMapPair -> {
-                    List<Lineage> newLineages = Lists.newArrayList(initial.first);
-                    List<Relationship> newRelationProperties = Lists.newArrayList(initial.second);
-                    newRelationProperties.add(lineageMapPair.second);
-                    newLineages.add(lineageMapPair.first);
-                    return new Pair<>(newLineages, newRelationProperties);
-                }).collect(toImmutableList());
-    }
-
     private List<Pair<Lineage, Relationship>> getMatchingLineageAndRelationProperties(Lineage originLineage,
-                                                                                      List<Lineage> destLineage,
+                                                                                      Map<Node, List<Lineage>> destLineageByDestNode,
                                                                                       CrossRelationship metaRelation,
                                                                                       RelationshipQuery relationQuery) {
         Direction direction = relationQuery.direction;
-        String destType = direction == INCOMING ? metaRelation.originType : metaRelation.destinationType;
         String originType = direction == INCOMING ? metaRelation.destinationType : metaRelation.originType;
         return Streams.stream(originLineage.nodesByType.get(originType).getRelationships(direction, CROSS_ATTRIBUTE))
-                .map(r -> {
+                .flatMap(r -> {
                     Node n = direction == INCOMING ? r.getStartNode() : r.getEndNode();
-                    return new Pair<>(n, r);
+                    return destLineageByDestNode.getOrDefault(n, ImmutableList.of()).stream()
+                            .map(lineage -> new Pair<>(lineage, r));
                 })
-                .flatMap(pair -> destLineage.stream()
-                        .filter(l -> l.nodesByType.get(destType).equals(pair.first))
-                        .map(lineage -> new Pair<>(lineage, pair.second)))
                 .collect(toImmutableList());
     }
 
@@ -654,11 +661,12 @@ public final class ExportExtension {
     }
 
     private ImmutableList<Lineages> exportLineages(FullQuery fullQuery, List<CrossRelationship> relations, Transaction tx) {
+        Map<ImmutableSet<String>, ImmutableSet<String>> commonChildrenCache = new HashMap<>();
         ImmutableList.Builder<Lineages> lineagesBuilder = ImmutableList.builder();
         for (int i = 0; i < fullQuery.exportQueries.size(); i++) {
             ExportQuery exportQuery = fullQuery.exportQueries.get(i);
             ImmutableSet.Builder<String> requiredChildren = ImmutableSet.<String>builder()
-                    .addAll(getCommonChildren(exportQuery.requiredAttributes, metaSchema));
+                    .addAll(getCommonChildren(exportQuery.requiredAttributes, metaSchema, commonChildrenCache));
             Optional<RelationshipQuery> previousQuery = i == 0 ? Optional.empty() : Optional.of(fullQuery.relationshipQueries.get(i - 1));
             Optional<RelationshipQuery> nextQuery = i == fullQuery.relationshipQueries.size() ?
                     Optional.empty() :
@@ -672,7 +680,7 @@ public final class ExportExtension {
             previousRel.ifPresent(q -> requiredChildren.add(q.first.direction == INCOMING ? q.second.originType : q.second.destinationType));
             nextRel.ifPresent(q -> requiredChildren.add(q.first.direction == INCOMING ? q.second.destinationType : q.second.originType));
 
-            lineagesBuilder.add(exportLineagesSingleQuery(requiredChildren.build(), exportQuery, previousRel, nextRel, tx));
+            lineagesBuilder.add(exportLineagesSingleQuery(requiredChildren.build(), exportQuery, previousRel, nextRel, tx, commonChildrenCache));
         }
         return lineagesBuilder.build();
     }
@@ -681,7 +689,8 @@ public final class ExportExtension {
                                                ExportQuery exportQuery,
                                                Optional<Pair<RelationshipQuery, CrossRelationship>> previousRel,
                                                Optional<Pair<RelationshipQuery, CrossRelationship>> nextRel,
-                                               Transaction tx) {
+                                               Transaction tx,
+                                               Map<ImmutableSet<String>, ImmutableSet<String>> commonChildrenCache) {
         List<String> filterAttributes = exportQuery.filter.columns()
                 .stream()
                 .map(c -> c.keyAttribute)
@@ -700,7 +709,7 @@ public final class ExportExtension {
         ImmutableSet<String> filterCommonChildren = allCombinations
                 .stream()
                 .map(ImmutableSet::copyOf)
-                .map(types -> getCommonChildren(types, metaSchema))
+                .map(types -> getCommonChildren(types, metaSchema, commonChildrenCache))
                 .reduce((set, set2) -> Sets.union(set, set2).immutableCopy())
                 .orElseGet(ImmutableSet::of);
         ImmutableList.Builder<String> relationAttrToExport = ImmutableList.builder();
@@ -741,38 +750,51 @@ public final class ExportExtension {
                                        Optional<Pair<RelationshipQuery, CrossRelationship>> previousRel,
                                        Optional<Pair<RelationshipQuery, CrossRelationship>> nextRel,
                                        Transaction tx) {
+        ImmutableList<ImmutableList<String>> previousUpwardPaths = previousRel
+                .map(pair -> {
+                    String destType = pair.first.direction == INCOMING ? pair.second.originType : pair.second.destinationType;
+                    return metaSchema.getUpwardPath(tx, nodeType, destType);
+                })
+                .orElse(null);
+        ImmutableList<ImmutableList<String>> nextUpwardPaths = nextRel
+                .map(pair -> {
+                    String destType = pair.first.direction == INCOMING ? pair.second.destinationType : pair.second.originType;
+                    return metaSchema.getUpwardPath(tx, nodeType, destType);
+                })
+                .orElse(null);
+
         return node -> {
-            AtomicBoolean result = new AtomicBoolean(true);
-            // check if previousRel is satisfied
-            previousRel.ifPresent(pair -> {
-                String destType = pair.first.direction == INCOMING ? pair.second.originType : pair.second.destinationType;
-                ImmutableList<ImmutableList<String>> upwardPaths = metaSchema.getUpwardPath(tx, nodeType, destType);
-                AtomicBoolean relRes = new AtomicBoolean(false);
-                for (ImmutableList<String> path : upwardPaths) {
-                    Optional<Node> optParent = getNodeFromPath(node, path);
-                    optParent.ifPresent(parent -> relRes.set(relRes.get() ||
-                            Streams.stream(parent.getRelationships(pair.first.direction == INCOMING ? OUTGOING : INCOMING, CROSS_ATTRIBUTE))
-                                    .anyMatch(r -> pair.first.type.equals(r.getProperty(_TYPE).toString()))));
+            if (previousUpwardPaths != null) {
+                Pair<RelationshipQuery, CrossRelationship> pair = previousRel.get();
+                Direction direction = pair.first.direction == INCOMING ? OUTGOING : INCOMING;
+                if (!hasMatchingRelation(node, previousUpwardPaths, pair.first.type, direction)) {
+                    return false;
                 }
-                result.set(result.get() && relRes.get());
-            });
-
-            // check if nextRel is satisfied
-            nextRel.ifPresent(pair -> {
-                String destType = pair.first.direction == INCOMING ? pair.second.destinationType : pair.second.originType;
-                ImmutableList<ImmutableList<String>> upwardPaths = metaSchema.getUpwardPath(tx, nodeType, destType);
-                AtomicBoolean relRes = new AtomicBoolean(false);
-                for (ImmutableList<String> path : upwardPaths) {
-                    Optional<Node> optParent = getNodeFromPath(node, path);
-                    optParent.ifPresent(parent -> relRes.set(relRes.get() ||
-                            Streams.stream(parent.getRelationships(pair.first.direction, CROSS_ATTRIBUTE))
-                                    .anyMatch(r -> pair.first.type.equals(r.getProperty(_TYPE).toString()))));
+            }
+            if (nextUpwardPaths != null) {
+                Pair<RelationshipQuery, CrossRelationship> pair = nextRel.get();
+                if (!hasMatchingRelation(node, nextUpwardPaths, pair.first.type, pair.first.direction)) {
+                    return false;
                 }
-                result.set(result.get() && relRes.get());
-            });
-
-            return result.get();
+            }
+            return true;
         };
+    }
+
+    /**
+     * Whether the given node has a parent (reached through one of the upwardPaths) with a CROSS_ATTRIBUTE
+     * relationship of relType in the given direction.
+     */
+    private boolean hasMatchingRelation(Node node, ImmutableList<ImmutableList<String>> upwardPaths, String relType, Direction direction) {
+        for (ImmutableList<String> path : upwardPaths) {
+            Optional<Node> optParent = getNodeFromPath(node, path);
+            if (optParent.isPresent() &&
+                    Streams.stream(optParent.get().getRelationships(direction, CROSS_ATTRIBUTE))
+                            .anyMatch(r -> relType.equals(r.getProperty(_TYPE).toString()))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Optional<Node> getNodeFromPath(Node initialNode, ImmutableList<String> path) {
@@ -786,10 +808,15 @@ public final class ExportExtension {
     }
 
 
+    private ImmutableSet<String> getCommonChildren(ImmutableSet<String> types, MetaSchema metaSchema,
+                                                    Map<ImmutableSet<String>, ImmutableSet<String>> cache) {
+        return cache.computeIfAbsent(types, t -> computeCommonChildren(t, metaSchema));
+    }
+
     /**
      * For a set of types, gives their common children of higher rank. If a common child has childs himself, those won't be returned
      */
-    private ImmutableSet<String> getCommonChildren(ImmutableSet<String> types, MetaSchema metaSchema) {
+    private ImmutableSet<String> computeCommonChildren(ImmutableSet<String> types, MetaSchema metaSchema) {
         List<ImmutableSet<ImmutableList<String>>> allLineages = types.stream()
                 .map(type -> metaSchema.getMetaLineagesForType(type)
                         .stream()
@@ -837,6 +864,7 @@ public final class ExportExtension {
         if (scopes.isEmpty()) {
             return tx.findNodes(Labels.ELEMENT, GraphModelConstants._TYPE, leafAttribute).stream();
         } else {
+            Map<Pair<String, String>, Node> planetCache = new HashMap<>();
             if (metaSchema.isOverridable(leafAttribute)) {
                 ImmutableSet<String> allPlanets = templatedPlanetFactory.getPlanetByContext(leafAttribute).allPlanets();
                 Set<Node> authorizedPlanets = scopes.stream()
@@ -851,7 +879,7 @@ public final class ExportExtension {
                             }
                             return possibleScopes.stream()
                                     .flatMap(scope -> allPlanets.stream()
-                                            .map(planetTemplate -> planetFactory.get(planetTemplate, scope, tx))
+                                            .map(planetTemplate -> getCachedPlanet(planetTemplate, scope, tx, planetCache))
                                             .filter(Objects::nonNull));
                         }).collect(Collectors.toSet());
                 return authorizedPlanets.stream()
@@ -863,13 +891,17 @@ public final class ExportExtension {
                 return scopes.stream()
                         .flatMap(scopeId ->
                                 planetByContext.allPlanets().stream()
-                                        .map(planetTemplate -> planetFactory.get(planetTemplate, scopeId, tx))
+                                        .map(planetTemplate -> getCachedPlanet(planetTemplate, scopeId, tx, planetCache))
                                         .filter(Objects::nonNull)
                                         .flatMap(planetNode -> StreamSupport.stream(planetNode.getRelationships(INCOMING, ATTRIBUTE).spliterator(), false)
                                                 .map(Relationship::getStartNode))
                                         .filter(node -> !node.getRelationships(OUTGOING, EXTEND).iterator().hasNext()));
             }
         }
+    }
+
+    private Node getCachedPlanet(String planetTemplate, String scopeId, Transaction tx, Map<Pair<String, String>, Node> cache) {
+        return cache.computeIfAbsent(new Pair<>(planetTemplate, scopeId), k -> planetFactory.get(planetTemplate, scopeId, tx));
     }
 
     /**
@@ -890,7 +922,7 @@ public final class ExportExtension {
     private Node getOverridingNode(Node element, Set<Node> authorizedPlanets) {
         return StreamSupport.stream(element.getRelationships(INCOMING, EXTEND).spliterator(), false)
                 .map(Relationship::getStartNode)
-                .filter(node -> authorizedPlanets.contains(Lists.newArrayList(node.getRelationships(OUTGOING, ATTRIBUTE)).get(0).getEndNode()))
+                .filter(node -> authorizedPlanets.contains(node.getRelationships(OUTGOING, ATTRIBUTE).iterator().next().getEndNode()))
                 .findAny()
                 .map(node -> getOverridingNode(node, authorizedPlanets))
                 .orElse(element);
@@ -902,7 +934,7 @@ public final class ExportExtension {
     }
 
     private Set<Lineage> rewindLineage(Node currentNode, Lineages lineages) {
-        return doRewind(currentNode, new HashMap<>(), lineages).stream()
+        return doRewind(currentNode, null, lineages).stream()
                 .map(nodesByType -> {
                     Lineage lineage = new Lineage(graphDb);
                     lineage.nodesByType.putAll(nodesByType);
@@ -910,14 +942,12 @@ public final class ExportExtension {
                 }).collect(toImmutableSet());
     }
 
-    private Set<Map<String, Node>> doRewind(Node currentNode, Map<String, Node> nodesByType, Lineages lineages) {
+    private Set<Map<String, Node>> doRewind(Node currentNode, NodePath path, Lineages lineages) {
         String type = currentNode.getProperty(_TYPE, "").toString();
-        if (lineages.attributesToExtract.contains(type)) {
-            nodesByType.put(type, currentNode);
-        }
+        NodePath updatedPath = lineages.attributesToExtract.contains(type) ? NodePath.append(path, type, currentNode) : path;
         lineages.markAsVisited(currentNode);
-        if (nodesByType.keySet().containsAll(lineages.attributesToExtract)) {
-            return ImmutableSet.of(nodesByType);
+        if (NodePath.containsAll(updatedPath, lineages.attributesToExtract)) {
+            return ImmutableSet.of(NodePath.toMap(updatedPath));
         }
         Iterable<Relationship> parentRelationships = currentNode.getRelationships(OUTGOING, CONNECT);
 
@@ -928,11 +958,11 @@ public final class ExportExtension {
         }
         ImmutableSetMultimap<String, Node> parentsByType = parentsByTypeB.build();
         if (parentsByType.isEmpty()) {
-            return ImmutableSet.of(nodesByType);
+            return ImmutableSet.of(NodePath.toMap(updatedPath));
         } else if (!lineages.parentsCardinality) {
             Map<String, Node> result = parentsByType.asMap().values().stream()
                     .map(parents -> parents.iterator().next())
-                    .map(parent -> doRewind(parent, Maps.newHashMap(nodesByType), lineages))
+                    .map(parent -> doRewind(parent, updatedPath, lineages))
                     .map(lineage -> {
                         if (lineage.size() > 1)
                             throw new IllegalArgumentException("Can't have more than 1 Lineage while parentsCardinality = false");
@@ -947,7 +977,7 @@ public final class ExportExtension {
         } else {
             return parentsByType.asMap().values().stream()
                     .map(parents -> parents.stream()
-                            .map(parent -> doRewind(parent, Maps.newHashMap(nodesByType), lineages))
+                            .map(parent -> doRewind(parent, updatedPath, lineages))
                             .reduce(ImmutableSet.of(), Sets::union)
                     ).reduce(ImmutableSet.of(), this::mergeBranches);
         }
@@ -1029,6 +1059,8 @@ public final class ExportExtension {
         String json = JSON_MAPPER.writeValueAsString(error);
         return Response.serverError().entity(json).type(MediaType.APPLICATION_JSON_TYPE).build();
     }
+
+
 
     public interface PaginatedLineages {
         ImmutableSet<String> attributesToExport();

--- a/src/main/java/com/livingobjects/neo4j/export/LineageChain.java
+++ b/src/main/java/com/livingobjects/neo4j/export/LineageChain.java
@@ -1,0 +1,56 @@
+package com.livingobjects.neo4j.export;
+
+import com.livingobjects.neo4j.model.export.Lineage;
+import org.neo4j.graphdb.Relationship;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A persistent (structurally-shared) chain of lineages joined by relationships, extended one relationship hop
+ * at a time.
+ * Appending a hop is O(1) (one new node pointing at its parent) instead of copying the whole accumulated
+ * List&lt;Lineage&gt;/List&lt;Relationship&gt; pair on every extension, which matters once a hop has wide fan-out
+ * (many matching relationships per line).
+ */
+public final class LineageChain {
+    public final Lineage lineage;
+    public final Relationship relationshipFromParent;
+    public final LineageChain parent;
+    public final int size;
+
+    private LineageChain(Lineage lineage, Relationship relationshipFromParent, LineageChain parent, int size) {
+        this.lineage = lineage;
+        this.relationshipFromParent = relationshipFromParent;
+        this.parent = parent;
+        this.size = size;
+    }
+
+    public static LineageChain first(Lineage lineage) {
+        return new LineageChain(lineage, null, null, 1);
+    }
+
+    public LineageChain append(Lineage lineage, Relationship relationship) {
+        return new LineageChain(lineage, relationship, this, size + 1);
+    }
+
+    public List<Lineage> toLineageList() {
+        Lineage[] result = new Lineage[size];
+        LineageChain current = this;
+        for (int idx = size - 1; idx >= 0; idx--) {
+            result[idx] = current.lineage;
+            current = current.parent;
+        }
+        return Arrays.asList(result);
+    }
+
+    public List<Relationship> toRelationshipList() {
+        Relationship[] result = new Relationship[size - 1];
+        LineageChain current = this;
+        for (int idx = size - 2; idx >= 0; idx--) {
+            result[idx] = current.relationshipFromParent;
+            current = current.parent;
+        }
+        return Arrays.asList(result);
+    }
+}

--- a/src/main/java/com/livingobjects/neo4j/export/NodePath.java
+++ b/src/main/java/com/livingobjects/neo4j/export/NodePath.java
@@ -1,0 +1,56 @@
+package com.livingobjects.neo4j.export;
+
+import org.neo4j.graphdb.Node;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A persistent (structurally-shared) chain of (type, node) entries accumulated while walking a lineage upward.
+ * Extending it is O(1) (one new node pointing at its parent) and safe to share across
+ * sibling branches (multiple parents, or multiple parent-type groups) without copying, unlike a plain
+ * Map&lt;String, Node&gt; that would need a full copy at every recursive step to keep branches independent.
+ * The flat Map&lt;String, Node&gt; is only materialized once a branch actually terminates.
+ */
+public final class NodePath {
+    public final String type;
+    public final Node node;
+    public final NodePath parent;
+
+    private NodePath(String type, Node node, NodePath parent) {
+        this.type = type;
+        this.node = node;
+        this.parent = parent;
+    }
+
+    public static NodePath append(NodePath path, String type, Node node) {
+        return new NodePath(type, node, path);
+    }
+
+    public static boolean containsAll(NodePath path, Set<String> types) {
+        for (String type : types) {
+            if (!contains(path, type)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean contains(NodePath path, String wantedType) {
+        for (NodePath p = path; p != null; p = p.parent) {
+            if (p.type.equals(wantedType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static Map<String, Node> toMap(NodePath path) {
+        Map<String, Node> result = new HashMap<>();
+        for (NodePath p = path; p != null; p = p.parent) {
+            result.putIfAbsent(p.type, p.node);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/livingobjects/neo4j/loader/MetaSchema.java
+++ b/src/main/java/com/livingobjects/neo4j/loader/MetaSchema.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -53,6 +54,9 @@ public final class MetaSchema {
     private final ImmutableMap<String, ImmutableSet<Tuple2<String, String>>> crossAttributesRelations;
 
     private final ImmutableList<ImmutableList<String>> metaLineages;
+
+    private final Map<String, ImmutableList<ImmutableList<String>>> metaLineagesForTypeCache = new ConcurrentHashMap<>();
+    private final Map<List<String>, ImmutableList<ImmutableList<String>>> upwardPathCache = new ConcurrentHashMap<>();
 
     // Comparator for 2 attributes: o1 > o2 => o2 -[:Parent*0..n]-> o1
     private final Function<Transaction, Comparator<String>> lineageComparator = tx -> (o1, o2) -> {
@@ -315,10 +319,12 @@ public final class MetaSchema {
     }
 
     public ImmutableList<ImmutableList<String>> getMetaLineagesForType(String type) {
-        List<ImmutableList<String>> result = metaLineages.stream()
-                .filter(lineage -> lineage.contains(type))
-                .collect(Collectors.toList());
-        return ImmutableList.copyOf(result);
+        return metaLineagesForTypeCache.computeIfAbsent(type, t -> {
+            List<ImmutableList<String>> result = metaLineages.stream()
+                    .filter(lineage -> lineage.contains(t))
+                    .collect(Collectors.toList());
+            return ImmutableList.copyOf(result);
+        });
     }
 
     /**
@@ -344,8 +350,13 @@ public final class MetaSchema {
         if (destType.equals(originType)) {
             return ImmutableList.of(ImmutableList.of());
         }
-        return ImmutableList.copyOf(getParentRelations(tx)
-                .get(originType)
+        List<String> cacheKey = ImmutableList.of(originType, destType);
+        ImmutableList<ImmutableList<String>> cached = upwardPathCache.get(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+        // Recursive: computeIfAbsent must not be used here, it would re-enter this same ConcurrentHashMap.
+        ImmutableList<ImmutableList<String>> computed = ImmutableList.copyOf(resolveParentRelations(tx, originType)
                 .stream()
                 .map(Relationship::getEndNode)
                 .map(this::getKeyAttribute)
@@ -357,6 +368,18 @@ public final class MetaSchema {
                                         .addAll(path)
                                         .build()))
                 .collect(Collectors.toList()));
+        upwardPathCache.put(cacheKey, computed);
+        return computed;
+    }
+
+    /**
+     * Resolves the parent relationships of a single keyAttribute, without rebuilding the relationships of every
+     * other keyAttribute in the schema like {@link #getParentRelations(Transaction)} does.
+     */
+    private ImmutableList<Relationship> resolveParentRelations(Transaction tx, String keyAttribute) {
+        return parentRelations.getOrDefault(keyAttribute, ImmutableList.of()).stream()
+                .map(tx::getRelationshipById)
+                .collect(ImmutableList.toImmutableList());
     }
 
     private boolean recursiveLineageComparator(Transaction tx, String o1, String o2) {

--- a/src/test/java/com/livingobjects/neo4j/ExportExtensionPerformanceTest.java
+++ b/src/test/java/com/livingobjects/neo4j/ExportExtensionPerformanceTest.java
@@ -1,0 +1,67 @@
+package com.livingobjects.neo4j;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.livingobjects.neo4j.model.export.query.Column;
+import com.livingobjects.neo4j.model.export.query.ExportQuery;
+import com.livingobjects.neo4j.model.export.query.FullQuery;
+import com.livingobjects.neo4j.model.export.query.filter.Filter;
+import com.livingobjects.neo4j.rules.WithNeo4jImpermanentDatabase;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.neo4j.logging.Log;
+
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Used to test performance on a big export query.
+ * This test takes really long to complete (several minutes only for database loading).
+ * This should remain Ignored and only be run manually, when testing the inventory performance after a change that might impact it significantly
+ *
+ * The query used returns wanLinks / Viewpoints on a topology of 500 clients, each having 800 sites and multiple cpe / viewpoint / wanLink for a total of ~2.2M lines returned
+ *
+ * To run this, you MUST add -Xmx16g (and optionally -Xms16g) to the "VM options" of the IDE running it (or use mvn -o test -Dtest=ExportExtensionPerformanceTest -DargLine="-Xmx12g")
+ * During the test, close other RAM-hungry applications and monitor memory usage with htop (might swap which would impact performance)
+ *
+ * NOTE: Unit test database is InMemory, so we don't suffer from the slowness of disk access here
+ */
+@Ignore
+public class ExportExtensionPerformanceTest {
+
+    private static final int CLIENT_COUNT = 1000;
+    private static final int SITES_PER_CLIENT = 800;
+    private static final int SITE_COUNT = CLIENT_COUNT * SITES_PER_CLIENT;
+
+    @Rule
+    public WithNeo4jImpermanentDatabase wNeo = new WithNeo4jImpermanentDatabase()
+            .withDatapacks("neo4j-test-database")
+            .withFixture(Paths.get("fixtures/performance"));
+
+    @Test
+    public void shouldExportBigWanLinkAndViewpointDatasetInReasonableTime() {
+        ExportExtension extension = new ExportExtension(wNeo.getDatabaseManagementService(), Mockito.mock(Log.class));
+
+        Filter<Column> noFilter = new Filter.AndFilter<>(ImmutableList.of());
+        ExportQuery exportQuery = new ExportQuery(
+                ImmutableSet.of("neType:wanLink", "neType:viewpoint"),
+                ImmutableSet.of("neType:cpe", "cluster:site", "cluster:area", "cluster:network", "cluster:client"),
+                ImmutableMap.of(),
+                noFilter,
+                false,
+                ImmutableSet.of(),
+                true,
+                false);
+        FullQuery fullQuery = new FullQuery(ImmutableList.of(exportQuery), null, null, null);
+
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        ExportExtension.PaginatedLineages result = extension.extract(fullQuery);
+        long elapsedMs = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+        System.out.println("ExportExtension.extract() took " + elapsedMs + " ms for " + result.total() + " lines "
+                + "(" + SITE_COUNT + " wanLinks + " + SITE_COUNT + " viewpoints in the source dataset).");
+    }
+}

--- a/src/test/java/com/livingobjects/neo4j/ExportExtensionTest.java
+++ b/src/test/java/com/livingobjects/neo4j/ExportExtensionTest.java
@@ -1,0 +1,172 @@
+package com.livingobjects.neo4j;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.livingobjects.neo4j.model.export.query.Column;
+import com.livingobjects.neo4j.model.export.query.ExportQuery;
+import com.livingobjects.neo4j.model.export.query.ExportQueryResult;
+import com.livingobjects.neo4j.model.export.query.FullQuery;
+import com.livingobjects.neo4j.model.export.query.Pair;
+import com.livingobjects.neo4j.model.export.query.RelationshipQuery;
+import com.livingobjects.neo4j.model.export.query.RelationshipQueryResult;
+import com.livingobjects.neo4j.model.export.query.filter.Filter;
+import com.livingobjects.neo4j.model.export.query.filter.ValueFilter;
+import com.livingobjects.neo4j.rules.WithNeo4jImpermanentDatabase;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.logging.Log;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ExportExtensionTest {
+
+    private static final Filter<Column> NO_FILTER = new Filter.AndFilter<>(ImmutableList.of());
+    private static final ImmutableSet<String> CLIENT_1_SCOPE = ImmutableSet.of("1");
+
+    @Rule
+    public WithNeo4jImpermanentDatabase wNeo = new WithNeo4jImpermanentDatabase()
+            .withDatapacks("neo4j-test-database");
+
+    private ExportExtension exportExtension;
+
+    @Before
+    public void setUp() {
+        exportExtension = new ExportExtension(wNeo.getDatabaseManagementService(), Mockito.mock(Log.class));
+    }
+
+    @Test
+    public void shouldFindAllCpeAndSiteWithAllProperties() {
+        ExportQuery exportQuery = new ExportQuery(
+                ImmutableSet.of("neType:cpe"),
+                ImmutableSet.of("cluster:site"),
+                ImmutableMap.of(),
+                NO_FILTER,
+                false,
+                CLIENT_1_SCOPE,
+                false,
+                false);
+        FullQuery fullQuery = new FullQuery(ImmutableList.of(exportQuery), null, null, null);
+
+        ExportExtension.PaginatedLineages result = exportExtension.extract(fullQuery);
+
+        Assertions.assertThat(result.total()).isEqualTo(7);
+
+        Set<Pair<String, String>> cpeToSite = result.results().stream()
+                .map(pair -> pair.first.get(0))
+                .map(r -> new Pair<>(
+                        (String) r.result.get("neType:cpe").get("name"),
+                        (String) r.result.get("cluster:site").get("name")))
+                .collect(Collectors.toSet());
+
+        Assertions.assertThat(cpeToSite).containsExactlyInAnyOrder(
+                new Pair<>("CC_RJ45", "Site_1"),
+                new Pair<>("HW_3615", "Site_1"),
+                new Pair<>("AA_RJ45", "Site_2"),
+                new Pair<>("BB_3615", "Site_2"),
+                new Pair<>("CPE_WITH_NO_WAN_LINKS", "Site_2"),
+                new Pair<>("cpe6", "Site_4"),
+                new Pair<>("NA_4233", "Site_5"));
+
+        // Not restricting `columns` should still surface non-metadata properties beyond just tag/name/_type.
+        ExportQueryResult ccRj45 = result.results().stream()
+                .map(pair -> pair.first.get(0))
+                .filter(r -> "CC_RJ45".equals(r.result.get("neType:cpe").get("name")))
+                .findFirst()
+                .orElseThrow();
+        Assertions.assertThat(ccRj45.result.get("neType:cpe").get("ip")).isEqualTo("172.17.10.31");
+    }
+
+    @Test
+    public void shouldFilterOnCpeNameAndReturnCpeAndSite() {
+        Filter<Column> filter = new Filter.ColumnFilter<>(
+                new Column("neType:cpe", "name"),
+                new ValueFilter(false, ValueFilter.Operator.eq, "CC_RJ45"));
+        ExportQuery exportQuery = new ExportQuery(
+                ImmutableSet.of("neType:cpe"),
+                ImmutableSet.of("cluster:site"),
+                ImmutableMap.of(),
+                filter,
+                false,
+                CLIENT_1_SCOPE,
+                false,
+                false);
+        FullQuery fullQuery = new FullQuery(ImmutableList.of(exportQuery), null, null, null);
+
+        ExportExtension.PaginatedLineages result = exportExtension.extract(fullQuery);
+
+        Assertions.assertThat(result.total()).isEqualTo(1);
+        ExportQueryResult row = result.results().get(0).first.get(0);
+        Assertions.assertThat(row.result.get("neType:cpe").get("name")).isEqualTo("CC_RJ45");
+        Assertions.assertThat(row.result.get("cluster:site").get("name")).isEqualTo("Site_1");
+    }
+
+    @Test
+    public void shouldFindCommonWanLinkWhenFilteringCpeBySiteAndNetwork() {
+        Filter<Column> filter = new Filter.AndFilter<>(ImmutableList.of(
+                new Filter.ColumnFilter<>(new Column("cluster:site", "name"), new ValueFilter(false, ValueFilter.Operator.eq, "Site_4")),
+                new Filter.ColumnFilter<>(new Column("cluster:network", "name"), new ValueFilter(false, ValueFilter.Operator.eq, "Network 03"))
+        ));
+        ExportQuery exportQuery = new ExportQuery(
+                ImmutableSet.of("neType:cpe"),
+                ImmutableSet.of(),
+                ImmutableMap.of(),
+                filter,
+                false,
+                CLIENT_1_SCOPE,
+                false,
+                false);
+        FullQuery fullQuery = new FullQuery(ImmutableList.of(exportQuery), null, null, null);
+
+        ExportExtension.PaginatedLineages result = exportExtension.extract(fullQuery);
+
+        Assertions.assertThat(result.total()).isEqualTo(1);
+        ExportQueryResult row = result.results().get(0).first.get(0);
+        Assertions.assertThat(row.result.get("neType:cpe").get("name")).isEqualTo("cpe6");
+    }
+
+    @Test
+    public void shouldReturnOnlyMatchingCpePairForIpslaCrossAttributeRelation() {
+        Filter<Column> originFilter = new Filter.ColumnFilter<>(
+                new Column("neType:cpe", "name"),
+                new ValueFilter(false, ValueFilter.Operator.eq, "CC_RJ45"));
+        ExportQuery originQuery = new ExportQuery(
+                ImmutableSet.of("neType:cpe"),
+                ImmutableSet.of(),
+                ImmutableMap.of(),
+                originFilter,
+                false,
+                CLIENT_1_SCOPE,
+                false,
+                false);
+        ExportQuery destinationQuery = new ExportQuery(
+                ImmutableSet.of("neType:cpe"),
+                ImmutableSet.of(),
+                ImmutableMap.of(),
+                NO_FILTER,
+                false,
+                CLIENT_1_SCOPE,
+                false,
+                false);
+        RelationshipQuery relationshipQuery = new RelationshipQuery(Direction.OUTGOING, "ipsla", ImmutableList.of("latencyMs"));
+        FullQuery fullQuery = new FullQuery(
+                ImmutableList.of(originQuery, destinationQuery),
+                null,
+                null,
+                ImmutableList.of(relationshipQuery));
+
+        ExportExtension.PaginatedLineages result = exportExtension.extract(fullQuery);
+
+        Assertions.assertThat(result.total()).isEqualTo(1);
+        Pair<List<ExportQueryResult>, List<RelationshipQueryResult>> row = result.results().get(0);
+        Assertions.assertThat(row.first.get(0).result.get("neType:cpe").get("name")).isEqualTo("CC_RJ45");
+        Assertions.assertThat(row.first.get(1).result.get("neType:cpe").get("name")).isEqualTo("HW_3615");
+        Assertions.assertThat(row.second.get(0).result.get("latencyMs")).isEqualTo(15L);
+    }
+}

--- a/src/test/java/com/livingobjects/neo4j/rules/WithNeo4jImpermanentDatabase.java
+++ b/src/test/java/com/livingobjects/neo4j/rules/WithNeo4jImpermanentDatabase.java
@@ -88,7 +88,7 @@ public class WithNeo4jImpermanentDatabase extends ExternalResource {
                     fail(e.getLocalizedMessage());
                 }
             } else {
-                readPathAsQuery(cp);
+                readPathAsQuery(path);
             }
         }
         return this;
@@ -124,6 +124,10 @@ public class WithNeo4jImpermanentDatabase extends ExternalResource {
 
     public GraphDatabaseService getGraphDatabaseService() {
         return db;
+    }
+
+    public DatabaseManagementService getDatabaseManagementService() {
+        return databaseManagementService;
     }
 
     @Override

--- a/src/test/resources/datapacks/neo4j-test-database/009-CrossAttributeIpsla.cql
+++ b/src/test/resources/datapacks/neo4j-test-database/009-CrossAttributeIpsla.cql
@@ -1,0 +1,14 @@
+// Adds a schema-level CrossAttribute relationship type "ipsla" from neType:cpe to itself, plus 2 instance-level
+// CrossAttribute relationships of that type between 2 distinct pairs of existing cpes from
+// 007-NetworkElements_LIVINGOBJECTS.cql. Used by ExportExtensionTest's cross-attribute relationship scenario.
+MATCH (netCpe:Attribute {_type:'neType', name:'cpe'})
+CREATE (netCpe)-[:CrossAttribute {_type:'ipsla'}]->(netCpe)
+;
+
+MATCH (cpe1:NetworkElement {tag:'class=neType,cpe=CC_RJ45,neType=cpe'})
+MATCH (cpe2:NetworkElement {tag:'class=neType,cpe=HW_3615,neType=cpe'})
+MATCH (cpe3:NetworkElement {tag:'class=neType,cpe=AA_RJ45,neType=cpe'})
+MATCH (cpe4:NetworkElement {tag:'class=neType,cpe=BB_3615,neType=cpe'})
+CREATE (cpe1)-[:CrossAttribute {_type:'ipsla', latencyMs:15}]->(cpe2)
+CREATE (cpe3)-[:CrossAttribute {_type:'ipsla', latencyMs:99}]->(cpe4)
+;

--- a/src/test/resources/fixtures/performance/001-Clients-001-050.cql
+++ b/src/test/resources/fixtures/performance/001-Clients-001-050.cql
@@ -1,0 +1,51 @@
+// Performance fixture: 1000 independent clients, each with its own topology (1000
+// areas, 1000 networks, 1000 sites, 1000 cpes, 1000 wanLinks,
+// 1000 viewpoints per client), reusing existing Attribute types/cardinalities from
+// 002-scope_attributes.cql (no new Attribute nodes are created here). This mirrors production, where the graph is
+// a forest of many separate per-client topologies rather than one giant shared one.
+// Respects: cpe->site (1..1), site->client (1..1), wanLink->cpe (1..1), viewpoint->cpe (1..1),
+// and the two multi-parent (0..n) cardinalities, each capped at 3 parents per child:
+//   site->area (0..n) and wanLink->cluster:network (0..n).
+// Batched into 20 files of 50 clients each so every file/transaction only holds one
+// batch's worth of data in memory at a time (see WithNeo4jImpermanentDatabase: one transaction per file).
+
+UNWIND range(1, 50) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(1, 50) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(1, 50) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(1, 50) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;

--- a/src/test/resources/fixtures/performance/002-Clients-051-100.cql
+++ b/src/test/resources/fixtures/performance/002-Clients-051-100.cql
@@ -1,0 +1,40 @@
+UNWIND range(51, 100) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(51, 100) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(51, 100) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(51, 100) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;

--- a/src/test/resources/fixtures/performance/003-Clients-101-150.cql
+++ b/src/test/resources/fixtures/performance/003-Clients-101-150.cql
@@ -1,0 +1,40 @@
+UNWIND range(101, 150) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(101, 150) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(101, 150) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(101, 150) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;

--- a/src/test/resources/fixtures/performance/004-Clients-151-200.cql
+++ b/src/test/resources/fixtures/performance/004-Clients-151-200.cql
@@ -1,0 +1,40 @@
+UNWIND range(151, 200) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(151, 200) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(151, 200) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(151, 200) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;

--- a/src/test/resources/fixtures/performance/005-Clients-201-250.cql
+++ b/src/test/resources/fixtures/performance/005-Clients-201-250.cql
@@ -1,0 +1,40 @@
+UNWIND range(201, 250) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(201, 250) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(201, 250) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(201, 250) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;

--- a/src/test/resources/fixtures/performance/006-Clients-251-300.cql
+++ b/src/test/resources/fixtures/performance/006-Clients-251-300.cql
@@ -1,0 +1,40 @@
+UNWIND range(251, 300) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(251, 300) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(251, 300) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(251, 300) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;

--- a/src/test/resources/fixtures/performance/007-Clients-301-350.cql
+++ b/src/test/resources/fixtures/performance/007-Clients-301-350.cql
@@ -1,0 +1,40 @@
+UNWIND range(301, 350) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(301, 350) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(301, 350) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(301, 350) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;

--- a/src/test/resources/fixtures/performance/008-Clients-351-400.cql
+++ b/src/test/resources/fixtures/performance/008-Clients-351-400.cql
@@ -1,0 +1,40 @@
+UNWIND range(351, 400) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(351, 400) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(351, 400) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(351, 400) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;

--- a/src/test/resources/fixtures/performance/009-Clients-401-450.cql
+++ b/src/test/resources/fixtures/performance/009-Clients-401-450.cql
@@ -1,0 +1,40 @@
+UNWIND range(401, 450) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(401, 450) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(401, 450) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(401, 450) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;

--- a/src/test/resources/fixtures/performance/010-Clients-451-500.cql
+++ b/src/test/resources/fixtures/performance/010-Clients-451-500.cql
@@ -1,0 +1,40 @@
+UNWIND range(451, 500) AS c
+CREATE (client:Element:NetworkElement:Scope {tag:'class=cluster,cluster=client,client=perf' + c, name:'PerfClient' + c, _type:'cluster:client', id:'perf' + c, createdBy:'system', createdAt:1446047124000})
+WITH c, client
+UNWIND range(1, 800) AS ai
+CREATE (a:Element:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + ai, name:'PerfArea' + c + '_' + ai, _type:'cluster:area', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(a)
+WITH DISTINCT c, client
+UNWIND range(1, 800) AS ni
+CREATE (n:Element:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + ni, name:'PerfNetwork' + c + '_' + ni, _type:'cluster:network', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(n)
+;
+
+UNWIND range(451, 500) AS c
+UNWIND range(1, 800) AS s
+MATCH (client:NetworkElement {tag:'class=cluster,cluster=client,client=perf' + c})
+CREATE (site:Element:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s, name:'PerfSite' + c + '_' + s, _type:'cluster:site', createdBy:'system', createdAt:1446047124000})
+CREATE (client)<-[:Connect]-(site)
+CREATE (cpe:Element:NetworkElement {tag:'class=neType,neType=cpe,cpe=perf' + c + '_' + s, name:'PerfCpe' + c + '_' + s, _type:'neType:cpe', ip:'10.0.0.1', createdBy:'system', createdAt:1446047124000})
+CREATE (site)<-[:Connect]-(cpe)
+CREATE (wl:Element:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s, name:'PerfWanLink' + c + '_' + s, _type:'neType:wanLink', pollingIfIndex:1, createdAt:1446047124000, bandwidthIn:10000, bandwidthOut:10000})
+CREATE (cpe)<-[:Connect]-(wl)
+CREATE (vp:Element:NetworkElement {tag:'class=neType,neType=viewpoint,viewpoint=perf' + c + '_' + s, name:'PerfViewpoint' + c + '_' + s, _type:'neType:viewpoint', ifIndexes:[1], createdAt:1446047124000})
+CREATE (cpe)<-[:Connect]-(vp)
+;
+
+UNWIND range(451, 500) AS c
+UNWIND range(1, 800) AS s
+MATCH (site:NetworkElement {tag:'class=cluster,cluster=site,site=perf' + c + '_' + s})
+UNWIND range(0, s % 3) AS off
+MATCH (a:NetworkElement {tag:'class=cluster,cluster=area,area=perf' + c + 'area' + (((s + off - 1) % 1000) + 1)})
+CREATE (a)<-[:Connect]-(site)
+;
+
+UNWIND range(451, 500) AS c
+UNWIND range(1, 800) AS s
+MATCH (wl:NetworkElement {tag:'class=neType,neType=wanLink,wanLink=perf' + c + '_' + s})
+UNWIND range(0, (s + 1) % 3) AS off
+MATCH (n:NetworkElement {tag:'class=cluster,cluster=network,network=perf' + c + 'net' + (((s + off) % 1000) + 1)})
+CREATE (n)<-[:Connect]-(wl)
+;


### PR DESCRIPTION
Many perf improvements. Global idea is to use less memory / limit disk access

Main points:

Don't fetch the properties (=> disk access) before pagination
Cache what can be (metaschema, planets, ...) and don't make redundant calls in loops
Stop calling new HashMap() / new ArrayList() and making copies, instead use a custom object and chain them, only creating the Collection once
Added a unit test for export + a performance test that's Ignored (can be useful in some situations, though the unit test database is InMemory => no disk access

Test result on turbot (~85000 site / cpe / wanLink / viewpoint):

Router inventory before ~7700ms
Router inventory after ~3600ms
WAN inventory before OOM (impossible to load it)
WAN inventory after 8800ms
NOTE: turbot is in a pretty bad state regarding memory (very, very little memory available to grab)